### PR TITLE
Support for subprotocols via Sec-WebSocket-Protocol header

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,7 +1,11 @@
 
+ver 0.1.4 (2015-10-07)
+======================
+Add Sec-WebSocket-Protocol header
+
 ver 0.1.3 (2014-09-13)
 ======================
-Support Chorome manifest version 2.
+Support Chrome manifest version 2.
 
 ver 0.1.2 (2010-10-25)
 ======================
@@ -10,4 +14,3 @@ Improve UX.
 ver 0.1.1 (2010-10-18)
 ======================
 First release.
-

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
 	width: 100%;
-	font-family: font-family:'ƒqƒ‰ƒMƒmŠpƒS Pro W3','Hiragino Kaku Gothic Pro','ƒƒCƒŠƒI',Meiryo,'‚l‚r ‚oƒSƒVƒbƒN',sans-serif;
+	font-family: font-family:'ï¿½qï¿½ï¿½ï¿½Mï¿½mï¿½pï¿½S Pro W3','Hiragino Kaku Gothic Pro','ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½I',Meiryo,'ï¿½lï¿½r ï¿½oï¿½Sï¿½Vï¿½bï¿½N',sans-serif;
 	color: #000;
 	background-color: #eee;
 	font-size: 10pt;
@@ -34,6 +34,12 @@ label {
 
 #serverUrl {
 	width: 225px;
+	padding: 1px 3px;
+	border: 1px solid #999;
+}
+
+#protocolHeader {
+	width: 113px;
 	padding: 1px 3px;
 	border: 1px solid #999;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
 	width: 100%;
-	font-family: font-family:'�q���M�m�p�S Pro W3','Hiragino Kaku Gothic Pro','���C���I',Meiryo,'�l�r �o�S�V�b�N',sans-serif;
+	font-family: font-family:'ヒラギノ角ゴ Pro W3','Hiragino Kaku Gothic Pro','メイリオ',Meiryo,'ＭＳ Ｐゴシック',sans-serif;
 	color: #000;
 	background-color: #eee;
 	font-size: 10pt;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 			<button id="disconnectButton">Close</button>
 		</div>
 		<div>
+			<label>Sec-WebSocket-Protocol:</label>
+			<input type="text" id="protocolHeader" />
+		<div>
 			<label>Status:</label>
 			<span id="connectionStatus">CLOSED</span>
 		</div>

--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ new function() {
 
 	var open = function() {
 		var url = serverUrl.val();
-		// comma-separated protocol headers are passed as array
 		var protocol = protocolHeader.val();
 		if (protocol) {
+			// comma-separated protocol headers are passed as array
 			var protocols = protocol.replace(/\s/,'').split(',');
 			try {
 				ws = new WebSocket(url, protocols);

--- a/index.js
+++ b/index.js
@@ -13,9 +13,14 @@ new function() {
 
 	var open = function() {
 		var url = serverUrl.val();
-		var protocol = protocolHeader.val();
+		// comma-separated protocol headers are passed as array
+		var protocol = protocolHeader.val().replace(/\s/,'').split(',');;
 		if (protocol) {
-			ws = new WebSocket(url, protocol);
+			try {
+				ws = new WebSocket(url, protocol);
+			} catch (ex) {
+				alert(ex);
+			}
 		} else {
 			ws = new WebSocket(url);
 		}
@@ -51,8 +56,11 @@ new function() {
 		$('#messages').html('');
 	}
 
-	var onOpen = function() {
+	var onOpen = function(evt) {
 		console.log('OPENED: ' + serverUrl.val());
+		if (evt.currentTarget.protocol) {
+			console.log('Sec-WebSocket-Protocol: ' + evt.currentTarget.protocol);
+		}
 		connected = true;
 		connectionStatus.text('OPENED');
 		sendMessage.removeAttr('disabled');

--- a/index.js
+++ b/index.js
@@ -14,10 +14,11 @@ new function() {
 	var open = function() {
 		var url = serverUrl.val();
 		// comma-separated protocol headers are passed as array
-		var protocol = protocolHeader.val().replace(/\s/,'').split(',');;
+		var protocol = protocolHeader.val();
 		if (protocol) {
+			var protocols = protocol.replace(/\s/,'').split(',');
 			try {
-				ws = new WebSocket(url, protocol);
+				ws = new WebSocket(url, protocols);
 			} catch (ex) {
 				alert(ex);
 			}

--- a/index.js
+++ b/index.js
@@ -3,16 +3,22 @@ new function() {
 	var connected = false;
 
 	var serverUrl;
+	var protocolHeader;
 	var connectionStatus;
 	var sendMessage;
-	
+
 	var connectButton;
-	var disconnectButton; 
+	var disconnectButton;
 	var sendButton;
 
 	var open = function() {
 		var url = serverUrl.val();
-		ws = new WebSocket(url);
+		var protocol = protocolHeader.val();
+		if (protocol) {
+			ws = new WebSocket(url, protocol);
+		} else {
+			ws = new WebSocket(url);
+		}
 		ws.onopen = onOpen;
 		ws.onclose = onClose;
 		ws.onmessage = onMessage;
@@ -20,10 +26,11 @@ new function() {
 
 		connectionStatus.text('OPENING ...');
 		serverUrl.attr('disabled', 'disabled');
+		protocolHeader.attr('disabled', 'disabled');
 		connectButton.hide();
 		disconnectButton.show();
 	}
-	
+
 	var close = function() {
 		if (ws) {
 			console.log('CLOSING ...');
@@ -33,16 +40,17 @@ new function() {
 		connectionStatus.text('CLOSED');
 
 		serverUrl.removeAttr('disabled');
+		protocolHeader.removeAttr('disabled');
 		connectButton.show();
 		disconnectButton.hide();
 		sendMessage.attr('disabled', 'disabled');
 		sendButton.attr('disabled', 'disabled');
 	}
-	
+
 	var clearLog = function() {
 		$('#messages').html('');
 	}
-	
+
 	var onOpen = function() {
 		console.log('OPENED: ' + serverUrl.val());
 		connected = true;
@@ -50,21 +58,21 @@ new function() {
 		sendMessage.removeAttr('disabled');
 		sendButton.removeAttr('disabled');
 	};
-	
+
 	var onClose = function() {
 		console.log('CLOSED: ' + serverUrl.val());
 		ws = null;
 	};
-	
+
 	var onMessage = function(event) {
 		var data = event.data;
 		addMessage(data);
 	};
-	
+
 	var onError = function(event) {
 		alert(event.data);
 	}
-	
+
 	var addMessage = function(data, type) {
 		var msg = $('<pre>').text(data);
 		if (type === 'SENT') {
@@ -72,7 +80,7 @@ new function() {
 		}
 		var messages = $('#messages');
 		messages.append(msg);
-		
+
 		var msgBox = messages.get(0);
 		while (msgBox.childNodes.length > 1000) {
 			msgBox.removeChild(msgBox.firstChild);
@@ -83,32 +91,33 @@ new function() {
 	WebSocketClient = {
 		init: function() {
 			serverUrl = $('#serverUrl');
+			protocolHeader = $('#protocolHeader');
 			connectionStatus = $('#connectionStatus');
 			sendMessage = $('#sendMessage');
-			
+
 			connectButton = $('#connectButton');
-			disconnectButton = $('#disconnectButton'); 
+			disconnectButton = $('#disconnectButton');
 			sendButton = $('#sendButton');
-			
+
 			connectButton.click(function(e) {
 				close();
 				open();
 			});
-		
+
 			disconnectButton.click(function(e) {
 				close();
 			});
-			
+
 			sendButton.click(function(e) {
 				var msg = $('#sendMessage').val();
 				addMessage(msg, 'SENT');
 				ws.send(msg);
 			});
-			
+
 			$('#clearMessage').click(function(e) {
 				clearLog();
 			});
-			
+
 			var isCtrl;
 			sendMessage.keyup(function (e) {
 				if(e.which == 17) isCtrl=false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Simple WebSocket Client",
   "manifest_version": 2,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Construct custom Web Socket requests and handle responses to directly test your Web Socket services.",
   "icons": {
     "16":  "resources/icon_032.png",


### PR DESCRIPTION
addressing https://github.com/hakobera/Simple-WebSocket-Client/issues/5
- add input field for Sec-WebSocket-Protocol header
- add CSS for new input field
- parse header into array of subprotocols accepted by client
- add subprotocol header to websocket creation (failsafe)
- extend logging to print subprotocol chosen by server
